### PR TITLE
Fix Task Display and Dropdown Issues

### DIFF
--- a/backend/apps/tasks/serializers.py
+++ b/backend/apps/tasks/serializers.py
@@ -7,6 +7,8 @@ from .models import Task
 class TaskSerializer(serializers.ModelSerializer):
     priority_label = serializers.CharField(source='get_priority_display', read_only=True)
     status_label = serializers.CharField(source='get_status_display', read_only=True)
+    assigned_to_username = serializers.CharField(source='assigned_to.username', read_only=True, allow_null=True)
+    created_by_username = serializers.CharField(source='created_by.username', read_only=True)
 
     class Meta:
         model = Task

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -59,14 +59,13 @@ const Tasks = () => {
       // valueOptions: priorityOptions,
     },
     {
-      field: "assigned_to",
+      field: "assigned_to_username",
       headerName: "Assigned To",
       minWidth: 200,
       // editable: isAdmin,
-      type: "singleSelect",
     },
     {
-      field: "created_by",
+      field: "created_by_username",
       headerName: "Created By",
       minWidth: 200,
       editable: false,

--- a/frontend/src/popup/TaskPopup.tsx
+++ b/frontend/src/popup/TaskPopup.tsx
@@ -214,11 +214,13 @@ const TaskPopup = ({ task, open, onOpenChange }: TaskPopupProps) => {
                         Self Assign
                       </Select.Item>
                     )}
-                    {users?.map((user: User) => (
-                      <Select.Item key={user.id} value={user.id.toString()}>
-                        {user.username}
-                      </Select.Item>
-                    ))}
+                    {users
+                      ?.filter((user: User) => user.id !== auth?.user_info?.id)
+                      .map((user: User) => (
+                        <Select.Item key={user.id} value={user.id.toString()}>
+                          {user.username}
+                        </Select.Item>
+                      ))}
                   </Select.Content>
                 </Select.Root>
               )}

--- a/jules-scratch/verification/verify_task_popup.py
+++ b/jules-scratch/verification/verify_task_popup.py
@@ -6,10 +6,8 @@ def run_verification(page: Page):
     This function verifies the new features in the TaskPopup component.
     """
     # 1. Arrange: Go to the login page and log in.
-    page.goto("http://localhost:5174/login", timeout=60000)
+    page.goto("http://localhost:5175/login", timeout=60000)
     page.wait_for_load_state()
-    print(f"Page title: {page.title()}")
-    page.screenshot(path="jules-scratch/verification/login_page.png")
 
     page.get_by_placeholder("Username").fill("admin")
     page.get_by_placeholder("Password").fill("admin")
@@ -18,30 +16,33 @@ def run_verification(page: Page):
     # Wait for navigation to the dashboard
     expect(page).to_have_url(re.compile(".*dashboard"), timeout=60000)
 
-    # 2. Act: Navigate to the Tasks page and open the Add Task popup.
+    # 2. Act: Navigate to the Tasks page.
     page.get_by_role("link", name="Tasks").click()
     expect(page).to_have_url(re.compile(".*tasks"))
-    page.get_by_role("button", name="Add Task").click()
 
-    # 3. Assert: Check for the new features in the popup.
-    # Check that the dialog is open
+    # 3. Assert: Check the "Assigned To" column in the table.
+    # We can't check the exact username, but we can check it's not a number.
+    # This is a weak check, but it's better than nothing.
+    first_assigned_to_cell = page.locator('.MuiDataGrid-cell[data-field="assigned_to_username"]').first
+    expect(first_assigned_to_cell).not_to_have_text(re.compile(r"^\d+$"))
+
+    # 4. Act: Open the Add Task popup.
+    page.get_by_role("button", name="Add Task").click()
     dialog = page.get_by_role("dialog")
     expect(dialog).to_be_visible()
 
-    # Check for the date picker
-    date_picker = dialog.locator('input[type="date"]')
-    expect(date_picker).to_be_visible()
-
-    # Check for the assigned_to dropdown
+    # 5. Assert: Check the "Assigned To" dropdown for duplicates.
     assigned_to_dropdown = dialog.locator('//button[contains(.,"Assigned To")]')
-    expect(assigned_to_dropdown).to_be_visible()
+    assigned_to_dropdown.click()
 
-    # Check that the created_by field is not visible
-    created_by_field = dialog.get_by_placeholder("Created By")
-    expect(created_by_field).not_to_be_visible()
+    # Check that "Self Assign" is present.
+    expect(page.get_by_role("option", name="Self Assign")).to_be_visible()
 
-    # 4. Screenshot: Capture the final result for visual verification.
-    page.screenshot(path="jules-scratch/verification/task_popup_verification.png")
+    # Check that "admin" is not present (since it's the current user).
+    expect(page.get_by_role("option", name="admin")).not_to_be_visible()
+
+    # 6. Screenshot: Capture the final result for visual verification.
+    page.screenshot(path="jules-scratch/verification/final_verification.png")
 
 def main():
     with sync_playwright() as p:


### PR DESCRIPTION
This commit addresses two issues reported by the user:
1.  The 'Assigned To' column in the tasks table now displays the username instead of the user ID. This was fixed by updating the `TaskSerializer` in the backend and the `DataGrid` component in the frontend.
2.  The 'Assigned To' dropdown in the `TaskPopup` no longer shows duplicate entries for the current user. This was fixed by filtering the users list in the component.