### PR TITLE
Implement Role-Based Permissions and Fix UI Bugs

### DIFF
--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -2,18 +2,21 @@ import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { getTasks } from "../api/FetchFucntions";
 import { Button } from "@radix-ui/themes";
-// import useAuth from "../hooks/useAuth";
+import useAuth from "../hooks/useAuth";
+import { useDeleteTask } from "../hooks/useTasks";
 import TaskPopup from "../popup/TaskPopup";
 import type { Task } from "../types/Authtypes";
 import { DataGrid, GridActionsCellItem, type GridColDef } from "@mui/x-data-grid";
 import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
 
 const Tasks = () => {
-  // const { auth } = useAuth();
+  const { auth } = useAuth();
   const { data: tasks = [] } = useQuery<Task[]>({
     queryKey: ["tasks"],
     queryFn: getTasks,
   });
+  const deleteTaskMutation = useDeleteTask();
 
   const [open, setOpen] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
@@ -23,13 +26,16 @@ const Tasks = () => {
     setOpen(true);
   };
 
+  const handleDeleteTask = (id: number) => {
+    deleteTaskMutation.mutate(id);
+  };
+
   const columns: GridColDef[] = [
     { field: "title", headerName: "Title", minWidth: 150, editable: true },
     {
       field: "description",
       headerName: "Description",
       minWidth: 200,
-      // editable: isAdmin,
     },
     {
       field: "due_date",
@@ -48,21 +54,17 @@ const Tasks = () => {
       minWidth: 150,
       editable: true,
       type: "singleSelect",
-      // valueOptions: statusOptions,
     },
     {
       field: "priority",
       headerName: "Priority",
       minWidth: 150,
-      // editable: isAdmin,
       type: "singleSelect",
-      // valueOptions: priorityOptions,
     },
     {
       field: "assigned_to_username",
       headerName: "Assigned To",
       minWidth: 200,
-      // editable: isAdmin,
     },
     {
       field: "created_by_username",
@@ -75,14 +77,28 @@ const Tasks = () => {
     type: "actions",
     headerName: "Actions",
     width: 100,
-    getActions: (params) => [
-      <GridActionsCellItem
-        icon={<EditIcon />}
-        label="Edit"
-        onClick={() => handleEditTask(params.row)}
-        showInMenu={false}
-      />,
-    ],
+    getActions: (params) => {
+      const actions = [
+        <GridActionsCellItem
+          icon={<EditIcon />}
+          label="Edit"
+          onClick={() => handleEditTask(params.row)}
+          showInMenu={false}
+        />,
+      ];
+
+      if (auth?.user_info?.is_superadmin) {
+        actions.push(
+          <GridActionsCellItem
+            icon={<DeleteIcon />}
+            label="Delete"
+            onClick={() => handleDeleteTask(params.row.id)}
+            showInMenu={false}
+          />
+        );
+      }
+      return actions;
+    },
   }
   ];
 

--- a/jules-scratch/verification/verify_permissions.py
+++ b/jules-scratch/verification/verify_permissions.py
@@ -1,0 +1,90 @@
+import re
+from playwright.sync_api import sync_playwright, Page, expect
+
+def run_verification(page: Page):
+    """
+    This function verifies the new role-based permissions for tasks.
+    """
+    # 1. Test as a regular user (non-admin)
+    page.goto("http://localhost:5176/login", timeout=60000)
+    page.wait_for_load_state()
+
+    # Assuming a regular user exists with username 'user' and password 'password'
+    # This will fail if the user doesn't exist.
+    # To make this test more robust, we could create a user first via the API.
+    # For now, we'll assume the user exists.
+    page.get_by_placeholder("Username").fill("user")
+    page.get_by_placeholder("Password").fill("password")
+    page.get_by_role("button", name="Login").click()
+
+    # Wait for navigation to the dashboard
+    expect(page).to_have_url(re.compile(".*dashboard"), timeout=60000)
+
+    # Navigate to the Tasks page
+    page.get_by_role("link", name="Tasks").click()
+    expect(page).to_have_url(re.compile(".*tasks"))
+
+    # Open the first task for editing
+    page.locator('.MuiDataGrid-cell[data-field="actions"] button').first.click()
+    dialog = page.get_by_role("dialog")
+    expect(dialog).to_be_visible()
+
+    # Assert that only the status field is enabled
+    expect(dialog.get_by_placeholder("Title")).to_be_disabled()
+    expect(dialog.get_by_placeholder("Description")).to_be_disabled()
+    expect(dialog.locator('input[type="date"]')).to_be_disabled()
+    expect(dialog.get_by_role("combobox", name="Priority")).to_be_disabled()
+    expect(dialog.get_by_role("combobox", name="Assigned To")).to_be_disabled()
+
+    # Status should be enabled
+    expect(dialog.get_by_role("combobox", name="Status")).to_be_enabled()
+
+    # Close the dialog
+    dialog.get_by_role("button", name="Cancel").click()
+    expect(dialog).not_to_be_visible()
+
+    # Log out
+    page.get_by_role("button", name="Logout").click()
+    expect(page).to_have_url(re.compile(".*login"))
+
+
+    # 2. Test as an admin user
+    page.get_by_placeholder("Username").fill("admin")
+    page.get_by_placeholder("Password").fill("admin")
+    page.get_by_role("button", name="Login").click()
+
+    # Wait for navigation to the dashboard
+    expect(page).to_have_url(re.compile(".*dashboard"), timeout=60000)
+
+    # Navigate to the Tasks page
+    page.get_by_role("link", name="Tasks").click()
+    expect(page).to_have_url(re.compile(".*tasks"))
+
+    # Check for delete icon
+    delete_button = page.locator('[data-testid="DeleteIcon"]').first
+    expect(delete_button).to_be_visible()
+
+    # Open the first task for editing
+    page.locator('.MuiDataGrid-cell[data-field="actions"] button').first.click()
+    expect(dialog).to_be_visible()
+
+    # Assert that all fields are enabled for admin
+    expect(dialog.get_by_placeholder("Title")).to_be_enabled()
+    expect(dialog.get_by_placeholder("Description")).to_be_enabled()
+    expect(dialog.locator('input[type="date"]')).to_be_enabled()
+    expect(dialog.get_by_role("combobox", name="Status")).to_be_enabled()
+    expect(dialog.get_by_role("combobox", name="Priority")).to_be_enabled()
+    expect(dialog.get_by_role("combobox", name="Assigned To")).to_be_enabled()
+
+    # Screenshot: Capture the final result for visual verification.
+    page.screenshot(path="jules-scratch/verification/admin_edit_task_popup.png")
+
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        run_verification(page)
+        browser.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit implements new role-based permissions for editing and deleting tasks, and fixes several UI bugs.

Features:
- Superadmins can now edit all fields of a task, while regular users can only update the status.
- A delete icon is now visible for admins in the tasks table.

Fixes:
- The 'Assigned To' column in the tasks table now correctly displays the username instead of the user ID.
- The 'Assigned To' dropdown in the `TaskPopup` no longer shows duplicate entries for the current user.
- The `TaskPopup` now correctly handles its open/close state on mutation errors.
- The backend service layer is now used consistently for all user and task operations.
- All identified backend and frontend bugs from the previous code reviews have been addressed.