### PR TITLE
Implement Role-Based Permissions and Final Fixes

### DIFF
--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -11,7 +11,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 
 const Tasks = () => {
-  const { auth } = useAuth();
+  const { auth, loading } = useAuth();
   const { data: tasks = [] } = useQuery<Task[]>({
     queryKey: ["tasks"],
     queryFn: getTasks,
@@ -101,6 +101,8 @@ const Tasks = () => {
     },
   }
   ];
+
+  if (loading) return <div>Loading...</div>;
 
   return (
     <div>

--- a/frontend/src/popup/TaskPopup.tsx
+++ b/frontend/src/popup/TaskPopup.tsx
@@ -41,7 +41,7 @@ interface TaskPopupProps {
 }
 
 const TaskPopup = ({ task, open, onOpenChange }: TaskPopupProps) => {
-  const { auth } = useAuth();
+  const { auth, loading } = useAuth();
   const { data: users } = useUsers();
 
   const commonMutationOptions = {
@@ -128,6 +128,7 @@ const TaskPopup = ({ task, open, onOpenChange }: TaskPopupProps) => {
   };
 
   // Show loader or null until auth loaded
+  if (loading) return null; // Or a loading spinner
   if (!auth?.user_info) return null;
 
   return (


### PR DESCRIPTION
This commit introduces role-based permissions for editing tasks and includes a final round of bug fixes for both the backend and frontend.

Features:
- **Role-Based Editing:** Superadmins can now edit all fields of a task, while regular users can only update the status field. The backend `TaskService` enforces this logic.
- **Admin Delete Icon:** A delete icon for tasks is now visible only to admin users in the tasks table.

Fixes:
- **Backend:**
  - The `TaskService` now correctly handles task deletion.
  - The `UserService` is now used consistently for all user-related operations.
- **Frontend:**
  - A race condition causing incorrect UI state for admins has been fixed by checking the `loading` state from the `useAuth` hook.
  - The 'Assigned To' column in the tasks table now correctly displays the username.
  - The 'Assigned To' dropdown in the `TaskPopup` no longer shows duplicate entries.
  - The `TaskPopup` now correctly handles its open/close state on mutation errors.